### PR TITLE
Add zrl parameter support

### DIFF
--- a/src/classes/Content/Pager.php
+++ b/src/classes/Content/Pager.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Content;
 /**
  * The Pager has two very different output, Minimal and Full, see renderMinimal() and renderFull() for more details.
  *
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Pager
 {

--- a/src/classes/Controllers/Api/MatchSearch.php
+++ b/src/classes/Controllers/Api/MatchSearch.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class MatchSearch
 {

--- a/src/classes/Controllers/Api/Photo.php
+++ b/src/classes/Controllers/Api/Photo.php
@@ -6,7 +6,7 @@ use Slim\Http\Request;
 use Slim\Http\Response;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Photo
 {

--- a/src/classes/Controllers/Api/Search.php
+++ b/src/classes/Controllers/Api/Search.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Search
 {

--- a/src/classes/Controllers/Api/Submit.php
+++ b/src/classes/Controllers/Api/Submit.php
@@ -6,7 +6,7 @@ use Slim\Http\Request;
 use Slim\Http\Response;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Submit
 {

--- a/src/classes/Controllers/Api/Surprise.php
+++ b/src/classes/Controllers/Api/Surprise.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Surprise
 {

--- a/src/classes/Controllers/Api/SyncPull.php
+++ b/src/classes/Controllers/Api/SyncPull.php
@@ -6,7 +6,7 @@ use Slim\Http\Request;
 use Slim\Http\Response;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class SyncPull
 {

--- a/src/classes/Controllers/Console.php
+++ b/src/classes/Controllers/Console.php
@@ -7,7 +7,7 @@ use Monolog\Logger;
 /**
  * Description of Console
  *
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Console extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/DirectoryAdd.php
+++ b/src/classes/Controllers/Console/DirectoryAdd.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Controllers\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class DirectoryAdd extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/DirectoryPoll.php
+++ b/src/classes/Controllers/Console/DirectoryPoll.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Controllers\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class DirectoryPoll extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/ExtractStrings.php
+++ b/src/classes/Controllers/Console/ExtractStrings.php
@@ -6,7 +6,7 @@ use Gettext\Merge;
 use Gettext\Translations;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ExtractStrings extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/Install.php
+++ b/src/classes/Controllers/Console/Install.php
@@ -7,7 +7,7 @@ use Monolog\Logger;
 use Seld\CliPrompt\CliPrompt;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Install extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/ProfileAdd.php
+++ b/src/classes/Controllers/Console/ProfileAdd.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Controllers\Console;
 use Friendica\Directory\Models\ProfilePollQueue;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ProfileAdd extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/ProfileHide.php
+++ b/src/classes/Controllers/Console/ProfileHide.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Controllers\Console;
 use Friendica\Directory\Models\Profile;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ProfileHide extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/ProfilePoll.php
+++ b/src/classes/Controllers/Console/ProfilePoll.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Controllers\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ProfilePoll extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/ServerHide.php
+++ b/src/classes/Controllers/Console/ServerHide.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Controllers\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ServerHide extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/ServerPoll.php
+++ b/src/classes/Controllers/Console/ServerPoll.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Controllers\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ServerPoll extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Console/UpdateDb.php
+++ b/src/classes/Controllers/Console/UpdateDb.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Controllers\Console;
 use Monolog\Logger;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class UpdateDb extends \Asika\SimpleConsole\Console
 {

--- a/src/classes/Controllers/Cron.php
+++ b/src/classes/Controllers/Cron.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Controllers;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Cron
 {

--- a/src/classes/Controllers/Web/Directory.php
+++ b/src/classes/Controllers/Web/Directory.php
@@ -10,7 +10,7 @@ use Slim\Http\Request;
 use Slim\Http\Response;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Directory extends BaseController
 {

--- a/src/classes/Controllers/Web/Page.php
+++ b/src/classes/Controllers/Web/Page.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Controllers\Web;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Page extends BaseController
 {

--- a/src/classes/Controllers/Web/Search.php
+++ b/src/classes/Controllers/Web/Search.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Controllers\Web;
 use \Friendica\Directory\Content\Pager;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Search extends BaseController
 {

--- a/src/classes/Controllers/Web/Servers.php
+++ b/src/classes/Controllers/Web/Servers.php
@@ -8,7 +8,7 @@ use Slim\Http\Request;
 use Slim\Http\Response;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Servers extends BaseController
 {

--- a/src/classes/Controllers/Web/Statistics.php
+++ b/src/classes/Controllers/Web/Statistics.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Controllers\Web;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Statistics extends BaseController
 {

--- a/src/classes/Middleware/ZrlMiddleware.php
+++ b/src/classes/Middleware/ZrlMiddleware.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Friendica\Directory\Middleware;
+
+use Friendica\Directory\Views\PhpRenderer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * The ZRL middleware ensures the Renderer ZRL attribute is set if the query string parameter is present
+ *
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
+ * @package Friendica\Directory\Middleware
+ */
+class ZrlMiddleware
+{
+	/**
+	 * @var PhpRenderer
+	 */
+	private $phpRenderer;
+
+	public function __construct(PhpRenderer $phpRenderer)
+	{
+		$this->phpRenderer = $phpRenderer;
+	}
+
+	/**
+	 * @param ServerRequestInterface $request  PSR7 request
+	 * @param ResponseInterface      $response PSR7 response
+	 * @param callable               $next     Next middleware
+	 *
+	 * @return ResponseInterface
+	 */
+	public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+	{
+		$this->phpRenderer->addAttribute('zrl', $request->getQueryParams()['zrl'] ?? null);
+
+		return $next($request, $response);
+	}
+}

--- a/src/classes/Model.php
+++ b/src/classes/Model.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Model
 {

--- a/src/classes/Models/Profile.php
+++ b/src/classes/Models/Profile.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Models;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Profile extends \Friendica\Directory\Model
 {

--- a/src/classes/Models/ProfilePollQueue.php
+++ b/src/classes/Models/ProfilePollQueue.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Models;
 use Friendica\Directory\Utils\Network;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ProfilePollQueue extends \Friendica\Directory\Model
 {

--- a/src/classes/Models/Server.php
+++ b/src/classes/Models/Server.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Models;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Server extends \Friendica\Directory\Model
 {

--- a/src/classes/Pollers/Directory.php
+++ b/src/classes/Pollers/Directory.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Pollers;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Directory
 {

--- a/src/classes/Pollers/Profile.php
+++ b/src/classes/Pollers/Profile.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Pollers;
 use Friendica\Directory\Utils\Network;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Profile
 {

--- a/src/classes/Pollers/Server.php
+++ b/src/classes/Pollers/Server.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Pollers;
 use ByJG\Util\WebRequest;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Server
 {

--- a/src/classes/Routes/Console/BaseRoute.php
+++ b/src/classes/Routes/Console/BaseRoute.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 abstract class BaseRoute
 {

--- a/src/classes/Routes/Console/DirectoryAdd.php
+++ b/src/classes/Routes/Console/DirectoryAdd.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class DirectoryAdd extends BaseRoute
 {

--- a/src/classes/Routes/Console/DirectoryPoll.php
+++ b/src/classes/Routes/Console/DirectoryPoll.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class DirectoryPoll extends BaseRoute
 {

--- a/src/classes/Routes/Console/ExtractStrings.php
+++ b/src/classes/Routes/Console/ExtractStrings.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ExtractStrings extends BaseRoute
 {

--- a/src/classes/Routes/Console/Install.php
+++ b/src/classes/Routes/Console/Install.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Install extends BaseRoute
 {

--- a/src/classes/Routes/Console/ProfileAdd.php
+++ b/src/classes/Routes/Console/ProfileAdd.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ProfileAdd extends BaseRoute
 {

--- a/src/classes/Routes/Console/ProfileHide.php
+++ b/src/classes/Routes/Console/ProfileHide.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ProfileHide extends BaseRoute
 {

--- a/src/classes/Routes/Console/ProfilePoll.php
+++ b/src/classes/Routes/Console/ProfilePoll.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ProfilePoll extends BaseRoute
 {

--- a/src/classes/Routes/Console/ServerHide.php
+++ b/src/classes/Routes/Console/ServerHide.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ServerHide extends BaseRoute
 {

--- a/src/classes/Routes/Console/ServerPoll.php
+++ b/src/classes/Routes/Console/ServerPoll.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class ServerPoll extends BaseRoute
 {

--- a/src/classes/Routes/Console/UpdateDb.php
+++ b/src/classes/Routes/Console/UpdateDb.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Console;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class UpdateDb extends BaseRoute
 {

--- a/src/classes/Routes/Http/BaseRoute.php
+++ b/src/classes/Routes/Http/BaseRoute.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Http;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 abstract class BaseRoute
 {

--- a/src/classes/Routes/Http/MatchSearch.php
+++ b/src/classes/Routes/Http/MatchSearch.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Http;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class MatchSearch extends BaseRoute
 {

--- a/src/classes/Routes/Http/Photo.php
+++ b/src/classes/Routes/Http/Photo.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Http;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Photo extends BaseRoute
 {

--- a/src/classes/Routes/Http/Search.php
+++ b/src/classes/Routes/Http/Search.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Http;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Search extends BaseRoute
 {

--- a/src/classes/Routes/Http/Submit.php
+++ b/src/classes/Routes/Http/Submit.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Http;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Submit extends BaseRoute
 {

--- a/src/classes/Routes/Http/Surprise.php
+++ b/src/classes/Routes/Http/Surprise.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Http;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Surprise extends BaseRoute
 {

--- a/src/classes/Routes/Http/SyncPull.php
+++ b/src/classes/Routes/Http/SyncPull.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Http;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class SyncPull extends BaseRoute
 {

--- a/src/classes/Routes/Web/BaseRoute.php
+++ b/src/classes/Routes/Web/BaseRoute.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Routes\Web;
 use Friendica\Directory\Controllers\Web\BaseController;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 abstract class BaseRoute
 {

--- a/src/classes/Routes/Web/Directory.php
+++ b/src/classes/Routes/Web/Directory.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Web;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Directory extends BaseRoute
 {

--- a/src/classes/Routes/Web/Pages.php
+++ b/src/classes/Routes/Web/Pages.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Web;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Pages extends BaseRoute
 {

--- a/src/classes/Routes/Web/Search.php
+++ b/src/classes/Routes/Web/Search.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Web;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Search extends BaseRoute
 {

--- a/src/classes/Routes/Web/Servers.php
+++ b/src/classes/Routes/Web/Servers.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Web;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Servers extends BaseRoute
 {

--- a/src/classes/Routes/Web/Statistics.php
+++ b/src/classes/Routes/Web/Statistics.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Routes\Web;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Statistics extends BaseRoute
 {

--- a/src/classes/Utils/L10n.php
+++ b/src/classes/Utils/L10n.php
@@ -6,7 +6,7 @@ use Gettext\Languages\Language;
 use Gettext\Translator;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class L10n
 {

--- a/src/classes/Utils/Network.php
+++ b/src/classes/Utils/Network.php
@@ -11,7 +11,7 @@ namespace Friendica\Directory\Utils;
 /**
  * Description of Network
  *
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Network
 {

--- a/src/classes/Utils/Photo.php
+++ b/src/classes/Utils/Photo.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Utils;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Photo
 {

--- a/src/classes/Utils/Scrape.php
+++ b/src/classes/Utils/Scrape.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Utils;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class Scrape
 {

--- a/src/classes/Utils/Url.php
+++ b/src/classes/Utils/Url.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Friendica\Directory\Utils;
+
+/**
+ * URL related static utilities
+ *
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
+ * @package Friendica\Directory\Utils
+ */
+class Url
+{
+	/**
+	 * Mirror of parse_url function, puts components back together to form a URI.
+	 *
+	 * @param array $parsed
+	 * @return string
+	 */
+	public static function unparse(array $parsed)
+	{
+		$scheme    = $parsed['scheme'] ?? null;
+		$user      = $parsed['user'] ?? null;
+		$pass      = $parsed['pass'] ?? null;
+		$userinfo  = $pass !== null ? "$user:$pass" : $user;
+		$port      = $parsed['port'] ?? null;
+		$query     = $parsed['query'] ?? null;
+		$fragment  = $parsed['fragment'] ?? null;
+		$authority = ($userinfo !== null ? $userinfo . "@" : '') .
+			($parsed['host'] ?? '') .
+			($port ? ":$port" : '');
+
+		return	(!empty($scheme) ? $scheme . ":" : '') .
+			(strlen($authority) ? "//" . $authority : '') .
+			($parsed['path'] ?? '') .
+			(strlen($query) ? "?" . $query : '') .
+			(strlen($fragment) ? "#" . $fragment : '');
+	}
+}

--- a/src/classes/Views/PhpRenderer.php
+++ b/src/classes/Views/PhpRenderer.php
@@ -5,7 +5,7 @@ namespace Friendica\Directory\Views;
 /**
  * Zend-Escaper wrapper for Slim PHP Renderer
  *
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  *
  * @method string escapeHtml(string $value)
  * @method string escapeHtmlAttr(string $value)

--- a/src/classes/Views/PhpRenderer.php
+++ b/src/classes/Views/PhpRenderer.php
@@ -2,6 +2,9 @@
 
 namespace Friendica\Directory\Views;
 
+use Friendica\Directory\Utils\Url;
+use Slim\Router;
+
 /**
  * Zend-Escaper wrapper for Slim PHP Renderer
  *
@@ -32,10 +35,15 @@ class PhpRenderer extends \Slim\Views\PhpRenderer
 	 * @var \Gettext\TranslatorInterface
 	 */
 	private $l10n;
+	/**
+	 * @var Router
+	 */
+	private $router;
 
 	public function __construct(
 		\Zend\Escaper\Escaper $escaper,
 		\Gettext\TranslatorInterface $l10n,
+		Router $router,
 		string $templatePath = "",
 		array $attributes = array()
 	)
@@ -44,6 +52,7 @@ class PhpRenderer extends \Slim\Views\PhpRenderer
 
 		$this->escaper = $escaper;
 		$this->l10n = $l10n;
+		$this->router = $router;
 	}
 
 	public function e(string $value): string
@@ -58,7 +67,7 @@ class PhpRenderer extends \Slim\Views\PhpRenderer
 		} elseif (method_exists($this->l10n, $name)) {
 			return $this->l10n->$name(...$arguments);
 		} else {
-			throw new \Exception('Unknown PhpRendere magic method: ' . $name);
+			throw new \Exception('Unknown PhpRenderer magic method: ' . $name);
 		}
 	}
 
@@ -172,5 +181,45 @@ class PhpRenderer extends \Slim\Views\PhpRenderer
 		return !empty($args[1]) && is_array($args[1]) ? strtr($text, $args[1]) : vsprintf($text, $args);
 	}
 
+	/**
+	 * Return the URL of the provided route and parameters
+	 *
+	 * @param string $name
+	 * @param array  $data
+	 * @param array  $queryParams
+	 * @return string
+	 */
+	function r(string $name, array $data = [], array $queryParams = [])
+	{
+		if ($this->getAttribute('zrl')) {
+			$queryParams['zrl'] = $this->getAttribute('zrl');
+		}
 
+		return $this->router->pathFor($name, $data, $queryParams);
+	}
+
+	/**
+	 * Add sitewide ZRL support for external URLs
+	 *
+	 * @param string $url
+	 */
+	function u(string $url)
+	{
+		if ($this->getAttribute('zrl')) {
+			$queryParameters = [];
+
+			$parsed = parse_url($url);
+			if (!empty($parsed['query'])) {
+				parse_str($parsed['query'], $queryParameters);
+			}
+
+			$queryParameters['zrl'] = $this->getAttribute('zrl');
+
+			$parsed['query'] = http_build_query($queryParameters);
+
+			$url = Url::unparse($parsed);
+		}
+
+		return $url;
+	}
 }

--- a/src/classes/Views/Widget/AccountTypeTabs.php
+++ b/src/classes/Views/Widget/AccountTypeTabs.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Views\Widget;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class AccountTypeTabs
 {

--- a/src/classes/Views/Widget/PopularCountries.php
+++ b/src/classes/Views/Widget/PopularCountries.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Views\Widget;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class PopularCountries
 {

--- a/src/classes/Views/Widget/PopularLanguages.php
+++ b/src/classes/Views/Widget/PopularLanguages.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Views\Widget;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class PopularLanguages
 {

--- a/src/classes/Views/Widget/PopularTags.php
+++ b/src/classes/Views/Widget/PopularTags.php
@@ -3,7 +3,7 @@
 namespace Friendica\Directory\Views\Widget;
 
 /**
- * @author Hypolite Petovan <mrpetovan@gmail.com>
+ * @author Hypolite Petovan <hypolite@mrpetovan.com>
  */
 class PopularTags
 {

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -25,7 +25,12 @@ $container['escaper'] = function (ContainerInterface $c): Zend\Escaper\Escaper {
 // view renderer
 $container['renderer'] = function (ContainerInterface $c): Friendica\Directory\Views\PhpRenderer {
 	$settings = $c->get('settings')['renderer'];
-	return new Friendica\Directory\Views\PhpRenderer($c->get('escaper'), $c->get('l10n'), $settings['template_path']);
+	return new Friendica\Directory\Views\PhpRenderer(
+		$c->get('escaper'),
+		$c->get('l10n'),
+		$c->get('router'),
+		$settings['template_path']
+	);
 };
 
 // monolog

--- a/src/lang/ar/LC_MESSAGES/strings.po
+++ b/src/lang/ar/LC_MESSAGES/strings.po
@@ -1,26 +1,25 @@
-# Translators:
-# ButterflyOfFire, 2019
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: ButterflyOfFire, 2019\n"
 "Language-Team: Arabic (https://www.transifex.com/Friendica/teams/12172/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: ar\n"
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "السابقة"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "التالية"
 
@@ -36,47 +35,53 @@ msgstr "الأخيرة"
 msgid "People"
 msgstr "أشخاص"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "اللغة"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr ""
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "المنطقة"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "البلد"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "الخوادم العمومية"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr ""
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr ""
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "البحث"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -129,7 +134,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "اتبع"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "اللغة"
 
@@ -149,19 +155,23 @@ msgstr ""
 msgid "Account type tabs"
 msgstr ""
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr ""
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr ""
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "إصدار ثابت"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "إصدار قيد التطوير"
 
@@ -193,7 +203,8 @@ msgstr "اللغات الشائعة"
 msgid "Popular Tags"
 msgstr "الوسوم الشائعة"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "اللغة الافتراضية"
 
@@ -241,71 +252,51 @@ msgid "Profiles"
 msgstr "الملفات الشخصية"
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "اللغات"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "الخوادم"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-msgstr ""
-
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr ""
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr "الإصدارات"
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr ""
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
 msgstr ""
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr ""
 
@@ -316,3 +307,11 @@ msgstr ""
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
 msgstr "الشفرة المصدرية على غيت هب"
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
+msgstr ""

--- a/src/lang/cs/LC_MESSAGES/strings.po
+++ b/src/lang/cs/LC_MESSAGES/strings.po
@@ -1,26 +1,25 @@
-# Translators:
-# Aditoo, 2019
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: Aditoo, 2019\n"
 "Language-Team: Czech (https://www.transifex.com/Friendica/teams/12172/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: cs\n"
 "Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "Předchozí"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "Další"
 
@@ -36,47 +35,53 @@ msgstr "Poslední"
 msgid "People"
 msgstr "Lidé"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "Jazyk"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "Poloha"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "Region/kraj"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "Země"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "Veřejné servery"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Adresář Friendica"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "Termíny vyhledávání"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "Hledání"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -127,7 +132,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "Sledovat"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "Jazyk"
 
@@ -147,19 +153,23 @@ msgstr "Hledat podle štítku"
 msgid "Account type tabs"
 msgstr "Záložky typů účtů"
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr "Horní stránkování %s"
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr "Spodní stránkování %s"
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "Stabilní verze"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "Vývojová verze"
 
@@ -191,7 +201,8 @@ msgstr "Populární jazyky"
 msgid "Popular Tags"
 msgstr "Populární štítky"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "Výchozí jazyk"
 
@@ -235,83 +246,51 @@ msgid "Profiles"
 msgstr "Profily"
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
-msgstr ""
-"Tento adresář ví o <strong>%s zřetelných potenciálních profilových URL "
-"adresách</strong>."
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
+msgstr "Tento adresář ví o <strong>%s zřetelných potenciálních profilových URL adresách</strong>."
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "Jazyky"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr "Ze všech <strong>%s</strong> profilů hlásících svůj jazyk je tu:"
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "Servery"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-msgstr ""
-"Tento adresář ví o <strong>%s zřetelných potenciálních serverových URL "
-"adresách</strong>."
-
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
-msgstr ""
-"Z těch je tu <strong>%s domén (%s)</strong>, které byly alespoň jednou "
-"serverem Friendica."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
+msgstr "Tento adresář ví o <strong>%s zřetelných potenciálních serverových URL adresách</strong>."
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr "Z těch je tu <strong>%s domén (%s)</strong>, které byly alespoň jednou serverem Friendica."
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr "Z těch je tu:"
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-"<strong>%s veřejných serverů (%s)</strong> aktuálně otevřených registracím. "
-"<a href=\"/servers\">Podívejte se na ně!</a>"
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr "Ze všech <strong>%s</strong> serverů hlásících svůj jazyk je tu:"
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr "Verze"
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr "Ze všech <strong>%s</strong> serverů hlásících svou verzi je tu:"
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
-msgstr ""
-"Z těch je tu <strong>%s profilů (%s)</strong>, které byly alespoň jednou "
-"publikovány ve veřejném adresáři."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
+msgstr "Z těch je tu <strong>%s profilů (%s)</strong>, které byly alespoň jednou publikovány ve veřejném adresáři."
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-"Z těch je tu aktuálně <strong>%s dostupných profilů (%s)</strong>. <a "
-"href=\"/\">Podívejte se na ně!</a>"
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr "<strong>%s dostupných serverů (%s)</strong>"
 
@@ -322,3 +301,11 @@ msgstr "Adresář Friendica, verze %s"
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
 msgstr "Zdrojový kód na GitHubu"
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
+msgstr ""

--- a/src/lang/de/LC_MESSAGES/strings.po
+++ b/src/lang/de/LC_MESSAGES/strings.po
@@ -1,28 +1,25 @@
-# Translators:
-# Andreas H., 2018
-# Ulf Rompe <transifex.com@rompe.org>, 2019
-# Tobias Diekershoff <tobias.diekershoff@gmx.net>, 2019
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: Tobias Diekershoff <tobias.diekershoff@gmx.net>, 2019\n"
 "Language-Team: German (https://www.transifex.com/Friendica/teams/12172/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "Vorherige"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "Nächste"
 
@@ -38,47 +35,53 @@ msgstr "Letzte"
 msgid "People"
 msgstr "Leute"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "Sprache"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "Wohnort"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "Region"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "Land"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "Öffentlicher Server"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Friendica Verzeichnis"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "Suchbegriff"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "Suche"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -127,7 +130,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "Folge"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "Sprache"
 
@@ -147,19 +151,23 @@ msgstr "Suchbegriff"
 msgid "Account type tabs"
 msgstr "Konto-Typ Register"
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr "Top %s pagination"
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr "Bottom %s pagination"
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "Stabile Version"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "Entwickler Version"
 
@@ -191,7 +199,8 @@ msgstr "Häufige Sprachen"
 msgid "Popular Tags"
 msgstr "Beliebte Tags"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "Standard Sprache"
 
@@ -231,85 +240,51 @@ msgid "Profiles"
 msgstr "Profile"
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
-msgstr ""
-"Dieses Verzeichnis kennt <strong>%s unterschiedliche, potentielle Profil "
-"URLs</strong>"
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
+msgstr "Dieses Verzeichnis kennt <strong>%s unterschiedliche, potentielle Profil URLs</strong>"
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "Sprachen"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr "Von den <strong>%s</strong> Profilen, die ihre Sprache angeben, sind:"
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "Server"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-msgstr ""
-"Dieses Verzeichnis kennt <strong>%s unterschiedliche, potentielle Server "
-"URLs</strong>"
-
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
-msgstr ""
-"Von diesen gibt es <strong>%sDomänen(%s)</strong>, die zumindest einmal "
-"Friendica Knoten gewesen sind."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
+msgstr "Dieses Verzeichnis kennt <strong>%s unterschiedliche, potentielle Server URLs</strong>"
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr "Von diesen gibt es <strong>%sDomänen(%s)</strong>, die zumindest einmal Friendica Knoten gewesen sind."
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr "Von diesen sind:"
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-"<strong>%söffentliche Knoten (%s)</strong>, bei denen man sich derzeit einen"
-" Nutzerkonto einrichten kann. <a href=\"/servers\">Schau sie dir an!</a>"
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
-msgstr ""
-"Von den <strong>%s</strong> Servern, die ihre Spracheinstellung angeben, "
-"sind:"
+msgstr "Von den <strong>%s</strong> Servern, die ihre Spracheinstellung angeben, sind:"
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr "Versionen"
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr "Von den <strong>%s</strong> Servern, die ihre Version angeben, sind:"
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
-msgstr ""
-"Von diesen gibt es <strong>%sProfile (%s)</strong> die sich, zumindest "
-"einmal, für die Aufnahme in das öffentliche Verzeichnis entschlossen haben."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
+msgstr "Von diesen gibt es <strong>%sProfile (%s)</strong> die sich, zumindest einmal, für die Aufnahme in das öffentliche Verzeichnis entschlossen haben."
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-"Von diesen sind derzeit <strong>%sverfügbare Profile (%s)</strong>. <a "
-"href=\"/\">Schaue sie dir an!</a>"
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr "<strong>%sverfügbare Server (%s)</strong>"
 
@@ -320,3 +295,11 @@ msgstr "Friendica Verzeichnis Version %s"
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
 msgstr "Quellcode auf GitHub"
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
+msgstr ""

--- a/src/lang/en/LC_MESSAGES/strings.po
+++ b/src/lang/en/LC_MESSAGES/strings.po
@@ -35,27 +35,27 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr ""
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr ""
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr ""
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr ""
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr ""
 
@@ -161,12 +161,12 @@ msgstr ""
 msgid "Bottom %s pagination"
 msgstr ""
 
-#: src\templates\statistics.phtml:64
+#: src\templates\statistics.phtml:66
 #: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr ""
 
-#: src\templates\statistics.phtml:66
+#: src\templates\statistics.phtml:68
 #: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr ""
@@ -243,44 +243,40 @@ msgstr ""
 msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:15
-#: src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr ""
 
-#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:17
 msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr ""
 
-#: src\templates\statistics.phtml:27
+#: src\templates\statistics.phtml:28
 msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:28
+#: src\templates\statistics.phtml:29
 msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
 msgstr ""
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:38
-msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"/servers\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr ""
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr ""
 
@@ -288,11 +284,7 @@ msgstr ""
 msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
 msgstr ""
 
-#: src\templates\statistics.phtml:11
-msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr ""
 
@@ -302,4 +294,12 @@ msgstr ""
 
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
+msgstr ""
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
 msgstr ""

--- a/src/lang/en_GB/LC_MESSAGES/strings.po
+++ b/src/lang/en_GB/LC_MESSAGES/strings.po
@@ -1,26 +1,25 @@
-# Translators:
-# Andy H3 <andy@hubup.pro>, 2019
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: Andy H3 <andy@hubup.pro>, 2019\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/Friendica/teams/12172/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "Previous"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "Next"
 
@@ -36,47 +35,53 @@ msgstr "Last"
 msgid "People"
 msgstr "People"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "Language"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "Locality"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "Region"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "Country"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "Public servers"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Friendica directory"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "Search terms"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "Search"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -125,7 +130,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "Follow"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "Language"
 
@@ -145,19 +151,23 @@ msgstr "Search tag"
 msgid "Account type tabs"
 msgstr "Account type tabs"
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr "Top %s pagination"
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr "Bottom %s pagination"
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "Stable version"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "Develop version"
 
@@ -189,7 +199,8 @@ msgstr "Popular languages"
 msgid "Popular Tags"
 msgstr "Popular tags"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "Default language"
 
@@ -229,85 +240,51 @@ msgid "Profiles"
 msgstr "Profiles"
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
-msgstr ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
+msgstr "This directory knows about <strong>%s distinct potential profile URLs</strong>."
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "Languages"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
-msgstr ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
+msgstr "Out of <strong>%s</strong> profiles reporting their language there are:"
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "Servers"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-msgstr ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
-msgstr ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
+msgstr "This directory knows about <strong>%s distinct potential server URLs</strong>."
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr "Out of those, there are:"
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
-msgstr ""
-"Out of <strong>%s</strong> servers reporting their language there are:"
+msgstr "Out of <strong>%s</strong> servers reporting their language there are:"
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr "Versions"
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr "Out of <strong>%s</strong> servers reporting their version there are:"
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
-msgstr ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
+msgstr "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr "<strong>%s available servers (%s)</strong>"
 
@@ -318,3 +295,11 @@ msgstr "Friendica directory version %s"
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
 msgstr "Source code on GitHub"
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
+msgstr ""

--- a/src/lang/et/LC_MESSAGES/strings.po
+++ b/src/lang/et/LC_MESSAGES/strings.po
@@ -1,26 +1,25 @@
-# Translators:
-# Rain Hawk, 2019
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: Rain Hawk, 2019\n"
 "Language-Team: Estonian (https://www.transifex.com/Friendica/teams/12172/et/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: et\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "Eelmine"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "Järgmine"
 
@@ -36,47 +35,53 @@ msgstr "Viimane"
 msgid "People"
 msgstr "Inimesed"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "Keel"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "Asukoht"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "Regioon"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "Riik"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "Avalikud serverid"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Friendica Kataloog"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "Otsingu tingimused"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "Otsi"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -125,7 +130,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "Järgi"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "Keel"
 
@@ -145,19 +151,23 @@ msgstr "Otsingu tag"
 msgid "Account type tabs"
 msgstr "Konto tüübi sakid"
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr ""
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr ""
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "Stabiilne versioon"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "Arendusversioon"
 
@@ -189,7 +199,8 @@ msgstr "Populaarsed keeled"
 msgid "Popular Tags"
 msgstr "Polulaarsed tag`id"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "Peamine keel"
 
@@ -229,71 +240,51 @@ msgid "Profiles"
 msgstr "Profiilid"
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "Keeled"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "Serverid"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-msgstr ""
-
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr ""
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr ""
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr ""
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
 msgstr ""
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr ""
 
@@ -303,4 +294,12 @@ msgstr ""
 
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
+msgstr ""
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
 msgstr ""

--- a/src/lang/fr/LC_MESSAGES/strings.po
+++ b/src/lang/fr/LC_MESSAGES/strings.po
@@ -1,27 +1,25 @@
-# Translators:
-# Tobias Diekershoff <tobias.diekershoff@gmx.net>, 2018
-# Vladimir Núñez <lapoubelle111@gmail.com>, 2018
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: Vladimir Núñez <lapoubelle111@gmail.com>, 2018\n"
 "Language-Team: French (https://www.transifex.com/Friendica/teams/12172/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "Précédent"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "Suivant"
 
@@ -37,47 +35,53 @@ msgstr "Fin"
 msgid "People"
 msgstr "Utilisateurs"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "Langue"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "Localité"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "Région"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "Pays"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "Serveurs publics"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Répertoire Friendica"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "Mots-clés"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "Recherche"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -126,7 +130,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "Suivre"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "Langue"
 
@@ -146,19 +151,23 @@ msgstr "Rechercher ce tag"
 msgid "Account type tabs"
 msgstr "Onglets de type de compte"
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr "Pagination %s haute"
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr "Pagination %s basse"
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "Version stable"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "Version instable"
 
@@ -190,7 +199,8 @@ msgstr "Language populaires"
 msgid "Popular Tags"
 msgstr "Tags populaires"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "Langage de base"
 
@@ -230,73 +240,51 @@ msgid "Profiles"
 msgstr "Profils"
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "Langages"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr "parmi <strong>%s</strong>profil mentionnant leur langage il y a:"
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "Serveurs"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-msgstr ""
-
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr ""
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr "Parmi ceux-là, il y a:"
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr "Versions"
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr "Parmi <strong>%s</strong> serveurs mentionnant leur version il y a:"
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
 msgstr ""
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-"Parmi ceux-là, il y a actuellement <strong>%sprofils disponibles "
-"(%s)</strong>. <a href=\"/\">Vérifiez-les!</a>"
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr "<strong>%sserveurs disponibles(%s)</strong>"
 
@@ -307,3 +295,11 @@ msgstr "Friendica Annuaire version %s"
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
 msgstr "Code source sur GitHub"
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
+msgstr ""

--- a/src/lang/it/LC_MESSAGES/strings.po
+++ b/src/lang/it/LC_MESSAGES/strings.po
@@ -1,26 +1,25 @@
-# Translators:
-# fabrixxm <fabrix.xm@gmail.com>, 2019
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: fabrixxm <fabrix.xm@gmail.com>, 2019\n"
 "Language-Team: Italian (https://www.transifex.com/Friendica/teams/12172/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "Precedente"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "Successivo"
 
@@ -36,47 +35,53 @@ msgstr "Ultimo"
 msgid "People"
 msgstr "Persone"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "Lingua"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "Località"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "Regione"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "Nazione"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "Server Pubblici"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Directory Friendica"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "Termini di ricerca"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "Cerca"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -125,7 +130,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "Segui"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "Lingua"
 
@@ -145,19 +151,23 @@ msgstr "Cerca Tag"
 msgid "Account type tabs"
 msgstr "Tab tipo account"
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr "Paginazione superiore %s"
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr "Paginazione inferiore %s"
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "Versione Stabile"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "Versione di Sviluppo"
 
@@ -189,7 +199,8 @@ msgstr "Lingue Popolari"
 msgid "Popular Tags"
 msgstr "Tag Popolari"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "Lingua di Default"
 
@@ -229,84 +240,51 @@ msgid "Profiles"
 msgstr "Profili"
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
-msgstr ""
-"Questa directory conosce <strong> %s distinti URL profili "
-"potenziali</strong>."
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
+msgstr "Questa directory conosce <strong> %s distinti URL profili potenziali</strong>."
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "Lingue"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr "Di <strong>%s</strong> profili che riportano la loro lingua, ci sono:"
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "Server"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-msgstr ""
-"Questa directory conosce <strong>%s distinti URL di server "
-"potenziali</strong>."
-
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
-msgstr ""
-"Di questi, ci sono <strong>%s domini (%s)</strong> che sono stati un server "
-"Friendica almeno una volta."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
+msgstr "Questa directory conosce <strong>%s distinti URL di server potenziali</strong>."
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr "Di questi, ci sono <strong>%s domini (%s)</strong> che sono stati un server Friendica almeno una volta."
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr "Di questi, ci sono:"
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-"<strong>%s server publici (%s)</strong> al momento aperti a nuove "
-"registrazioni. <a href=\"/servers\">Dai un'occhiata!</a>"
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr "Di <strong>%s</strong> server che riportano la loro lingua, ci sono:"
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr "Versioni"
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
-msgstr ""
-"Di <strong>%s</strong> server che riportano la loro versione, ci sono:"
+msgstr "Di <strong>%s</strong> server che riportano la loro versione, ci sono:"
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
-msgstr ""
-"Di questi, ci sono <strong>%s profili (%s</strong> che hanno deciso di venir"
-" pubblicati nella directory pubblica almeno una volta."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
+msgstr "Di questi, ci sono <strong>%s profili (%s</strong> che hanno deciso di venir pubblicati nella directory pubblica almeno una volta."
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-"Di questi, ci sono al momento <strong>%s profili disponibili (%s)</strong>. "
-"<a href=\"/\">Dai un'occhiata!</a>"
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr "<strong>%s server disponibili (%s)</strong>"
 
@@ -317,3 +295,11 @@ msgstr "Friendica Directory versione %s"
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
 msgstr "Codice Sorgente su GitHub"
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
+msgstr ""

--- a/src/lang/ja/LC_MESSAGES/strings.po
+++ b/src/lang/ja/LC_MESSAGES/strings.po
@@ -1,26 +1,25 @@
-# Translators:
-# ozero dien <rgfx0020+misc@gmail.com>, 2019
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: ozero dien <rgfx0020+misc@gmail.com>, 2019\n"
 "Language-Team: Japanese (https://www.transifex.com/Friendica/teams/12172/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "前"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "次"
 
@@ -36,47 +35,53 @@ msgstr "最終"
 msgid "People"
 msgstr "人"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "言語"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "局所性"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "地域"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "国"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "パブリックサーバー"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Friendicaディレクトリ"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "検索ワード"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "サーチ"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -124,7 +129,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "フォロー"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "言語"
 
@@ -144,19 +150,23 @@ msgstr "検索タグ"
 msgid "Account type tabs"
 msgstr "アカウントタイプタブ"
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr "トップ %s のページネーション"
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr "下位 %s のページネーション"
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "安定版"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "バージョンを開発"
 
@@ -188,7 +198,8 @@ msgstr "人気のある言語"
 msgid "Popular Tags"
 msgstr "人気のタグ"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "既定の言語"
 
@@ -226,77 +237,51 @@ msgid "Profiles"
 msgstr "プロフィール"
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
 msgstr "このディレクトリは、<strong> %s の異なる潜在的なプロファイルURL </strong>を認識しています。"
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "言語"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr "<strong> %s </strong>の言語を報告するプロフィールには、次のものがあります。"
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "サーバー"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
+#: src\templates\statistics.phtml:28
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
 msgstr "このディレクトリは、<strong> %s の異なる潜在的なサーバーURL </strong>を認識しています。"
 
-#: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
-msgstr ""
-"それらのうち、少なくとも一度はFriendicaサーバーであった<strong> %s のドメイン（ %s ）</strong>があります。"
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr "それらのうち、少なくとも一度はFriendicaサーバーであった<strong> %s のドメイン（ %s ）</strong>があります。"
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr "これらのうち、次のものがあります。"
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-"<strong> %s のパブリックサーバー（ %s ）</strong>は現在登録のために開いています。 <a "
-"href=\"/servers\">それらをチェックしてください</a>"
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr "言語を報告している<strong> %s </strong>のサーバーのうち、次のものがあります。"
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr "バージョン"
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr "バージョンを報告している<strong> %s </strong>のサーバーのうち、次のものがあります。"
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
-msgstr ""
-"これらのうち、<strong> %s のプロファイル（ %s ）</strong>があり、パブリックディレクトリで少なくとも1回選択しました。"
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
+msgstr "これらのうち、<strong> %s のプロファイル（ %s ）</strong>があり、パブリックディレクトリで少なくとも1回選択しました。"
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-"それらのうち、現在<strong> %s の使用可能なプロファイル（ %s ）</strong>があります。 <a "
-"href=\"/\">チェックしてみてください</a>"
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr "<strong> %s のサーバが利用可能（ %s ）</strong>"
 
@@ -307,3 +292,11 @@ msgstr "Friendica Directory バージョン %s"
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
 msgstr "GitHubのソースコード"
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
+msgstr ""

--- a/src/lang/nl/LC_MESSAGES/strings.po
+++ b/src/lang/nl/LC_MESSAGES/strings.po
@@ -1,26 +1,25 @@
-# Translators:
-# Jeroen De Meerleer <me@jeroened.be>, 2018
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: Jeroen De Meerleer <me@jeroened.be>, 2018\n"
 "Language-Team: Dutch (https://www.transifex.com/Friendica/teams/12172/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "Vorige"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "Volgende"
 
@@ -36,47 +35,53 @@ msgstr "Laatste"
 msgid "People"
 msgstr "Mensen"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "Taal"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "Stad"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "Regio"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "Land"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "Publieke servers"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Friendica gids"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "Zoektermen"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "Zoeken"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -125,7 +130,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "Volg"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "Taal"
 
@@ -145,19 +151,23 @@ msgstr "Zoekwoord"
 msgid "Account type tabs"
 msgstr "Accounttype tabs"
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr "%s paginatie boven"
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr "%s paginatie beneden"
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "Stabiele versie"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "Ontwikkelingsversie"
 
@@ -189,7 +199,8 @@ msgstr "Populaire talen"
 msgid "Popular Tags"
 msgstr "Populaire tags"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "Standaard taal"
 
@@ -229,71 +240,51 @@ msgid "Profiles"
 msgstr ""
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
-msgstr ""
-
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
-msgid "Languages"
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
 msgstr ""
 
 #: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:46
+msgid "Languages"
 msgstr ""
 
-#: src\templates\statistics.phtml:26
-msgid "Servers"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr ""
 
 #: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
+msgid "Servers"
 msgstr ""
 
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr ""
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr ""
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr ""
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
 msgstr ""
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr ""
 
@@ -303,4 +294,12 @@ msgstr ""
 
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
+msgstr ""
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
 msgstr ""

--- a/src/lang/pl/LC_MESSAGES/strings.po
+++ b/src/lang/pl/LC_MESSAGES/strings.po
@@ -1,27 +1,25 @@
-# Translators:
-# Karol Kosek <krkkx@protonmail.com>, 2018
-# Waldemar Stoczkowski, 2018
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: Waldemar Stoczkowski, 2018\n"
 "Language-Team: Polish (https://www.transifex.com/Friendica/teams/12172/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: pl\n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "Poprzedni"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "Następny"
 
@@ -37,47 +35,53 @@ msgstr "Ostatni"
 msgid "People"
 msgstr "Przyjaciele"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "Język"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "Miejscowość"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "Region"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "Kraj"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "Serwery publiczne"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Katalog Friendica"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "Wyszukiwane hasła"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "Szukaj"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -128,7 +132,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "Śledzenie"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "Język"
 
@@ -148,19 +153,23 @@ msgstr "Wyszukaj tag"
 msgid "Account type tabs"
 msgstr "Konta typu karty"
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr "Górna %s paginacja"
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr "Dolna %s paginacja"
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "Wersja stabilna"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "Rozwój wersji"
 
@@ -192,7 +201,8 @@ msgstr "Popularne języki"
 msgid "Popular Tags"
 msgstr "Popularne tagi"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "Domyślny Język"
 
@@ -236,82 +246,51 @@ msgid "Profiles"
 msgstr "Profile"
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
-msgstr ""
-"Ten katalog zna <strong>%s różne adresy URL potencjalnych adresów</strong>."
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
+msgstr "Ten katalog zna <strong>%s różne adresy URL potencjalnych adresów</strong>."
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "Języki"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr "Poza <strong>%s</strong> profilami zgłaszającymi swój język są:"
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "Serwery"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-msgstr ""
-"Ten katalog wie o <strong>%s różnych potencjalnych adresach URL "
-"serwera</strong>."
-
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
-msgstr ""
-"Spośród nich są <strong>%s domeny (%s)</strong> które były serwerem "
-"Friendica co najmniej raz."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
+msgstr "Ten katalog wie o <strong>%s różnych potencjalnych adresach URL serwera</strong>."
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr "Spośród nich są <strong>%s domeny (%s)</strong> które były serwerem Friendica co najmniej raz."
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr "Wśród nich są:"
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-"<strong>%s publiczne serwery (%s)</strong> są obecnie otwarte do "
-"rejestracji. <a href=\"/servers\">Sprawdź je!</a>"
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr "Z<strong>%s</strong> serwerów raportujących ich język są:"
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr "Wersje"
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr "Poza <strong>%s</strong> serwerami raportującymi ich wersję są:"
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
-msgstr ""
-"Spośród nich są <strong>%s profile (%s)</strong> które wybrały katalog "
-"publiczny co najmniej raz."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
+msgstr "Spośród nich są <strong>%s profile (%s)</strong> które wybrały katalog publiczny co najmniej raz."
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-"Spośród nich obecnie <strong>%s dostępne są profile (%s)</strong>. <a "
-"href=\"/\">Sprawdź je!</a>"
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr "<strong>%s dostępne serwery (%s)</strong>"
 
@@ -322,3 +301,11 @@ msgstr "Katalog Friendica wersja %s"
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
 msgstr "Kod źródłowy na GitHub"
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
+msgstr ""

--- a/src/lang/th/LC_MESSAGES/strings.po
+++ b/src/lang/th/LC_MESSAGES/strings.po
@@ -1,26 +1,25 @@
-# Translators:
-# Andy H3 <andy@hubup.pro>, 2018
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: Andy H3 <andy@hubup.pro>, 2018\n"
 "Language-Team: Thai (Thailand) (https://www.transifex.com/Friendica/teams/12172/th_TH/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: th_TH\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "ก่อนหน้า"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "ถัดไป"
 
@@ -36,47 +35,53 @@ msgstr "สุดท้าย"
 msgid "People"
 msgstr "คน"
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "ภาษา"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr "สถาน"
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "แดน"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "ประเทศ"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "เซอร์เวอร์เปิด"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Friendica ทำเนียบ"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr "ค้น หา"
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "ค้น"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -124,7 +129,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr "ตาม"
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "ภาษา"
 
@@ -144,19 +150,23 @@ msgstr "ค้นหาด้วยแท็ก"
 msgid "Account type tabs"
 msgstr ""
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr ""
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr ""
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "เวอร์ชันเสถียร"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "เวอร์ชันพัฒนา"
 
@@ -188,7 +198,8 @@ msgstr "ภาษายอดนิยม"
 msgid "Popular Tags"
 msgstr "แท็กยอดนิยม"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "ภาษาเริ่มต้น"
 
@@ -226,71 +237,51 @@ msgid "Profiles"
 msgstr ""
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
-msgstr ""
-
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
-msgid "Languages"
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
 msgstr ""
 
 #: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:46
+msgid "Languages"
 msgstr ""
 
-#: src\templates\statistics.phtml:26
-msgid "Servers"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr ""
 
 #: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
+msgid "Servers"
 msgstr ""
 
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr ""
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr ""
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr ""
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
 msgstr ""
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr ""
 
@@ -300,4 +291,12 @@ msgstr ""
 
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
+msgstr ""
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
 msgstr ""

--- a/src/lang/zh_CN/LC_MESSAGES/strings.po
+++ b/src/lang/zh_CN/LC_MESSAGES/strings.po
@@ -1,26 +1,25 @@
-# Translators:
-# 朱陈锬 <tangenters@outlook.com>, 2019
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
-"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Last-Translator: 朱陈锬 <tangenters@outlook.com>, 2019\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/Friendica/teams/12172/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2018-11-16T04:17:37+00:00\n"
+"PO-Revision-Date: 2018-11-16 20:30+0000\n"
 "Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src\classes\Content\Pager.php:168 src\classes\Content\Pager.php:216
+#: src\classes\Content\Pager.php:168
+#: src\classes\Content\Pager.php:216
 msgid "Previous"
 msgstr "上一页"
 
-#: src\classes\Content\Pager.php:173 src\classes\Content\Pager.php:273
+#: src\classes\Content\Pager.php:173
+#: src\classes\Content\Pager.php:273
 msgid "Next"
 msgstr "下一页"
 
@@ -36,47 +35,53 @@ msgstr "最后一页"
 msgid "People"
 msgstr ""
 
-#: src\classes\Controllers\Web\Search.php:63
+#: src\classes\Controllers\Web\Search.php:64
 msgctxt "field"
 msgid "Language"
 msgstr "语言"
 
-#: src\classes\Controllers\Web\Search.php:64
+#: src\classes\Controllers\Web\Search.php:65
 msgctxt "field"
 msgid "Locality"
 msgstr ""
 
-#: src\classes\Controllers\Web\Search.php:65
+#: src\classes\Controllers\Web\Search.php:66
 msgctxt "field"
 msgid "Region"
 msgstr "地区"
 
-#: src\classes\Controllers\Web\Search.php:66
+#: src\classes\Controllers\Web\Search.php:67
 msgctxt "field"
 msgid "Country"
 msgstr "国家"
 
-#: src\classes\Controllers\Web\Servers.php:88
+#: src\classes\Controllers\Web\Servers.php:90
 msgid "Public Servers"
 msgstr "公共服务器"
 
-#: src\templates\layout.phtml:4 src\templates\layout.phtml:18
+#: src\templates\layout.phtml:4
+#: src\templates\layout.phtml:18
 msgid "Friendica Directory"
 msgstr "Friendica 目录"
 
-#: src\templates\layout.phtml:23 src\templates\layout.phtml:25
-#: src\templates\layout.phtml:43 src\templates\layout.phtml:45
-#: src\templates\search.phtml:4 src\templates\search.phtml:12
+#: src\templates\layout.phtml:23
+#: src\templates\layout.phtml:25
+#: src\templates\layout.phtml:43
+#: src\templates\layout.phtml:45
+#: src\templates\search.phtml:4
+#: src\templates\search.phtml:12
 msgid "Search terms"
 msgstr ""
 
-#: src\templates\layout.phtml:24 src\templates\layout.phtml:45
+#: src\templates\layout.phtml:24
+#: src\templates\layout.phtml:45
 #: src\templates\search.phtml:11
 msgctxt "noun"
 msgid "Search"
 msgstr "搜索"
 
-#: src\templates\layout.phtml:27 src\templates\layout.phtml:47
+#: src\templates\layout.phtml:27
+#: src\templates\layout.phtml:47
 #: src\templates\search.phtml:14
 msgctxt "verb"
 msgid "Search"
@@ -124,7 +129,8 @@ msgctxt "verb"
 msgid "Follow"
 msgstr ""
 
-#: src\templates\layout.phtml:65 src\templates\sub\profile.phtml:47
+#: src\templates\layout.phtml:65
+#: src\templates\sub\profile.phtml:47
 msgid "Language"
 msgstr "语言"
 
@@ -144,19 +150,23 @@ msgstr "搜索标签"
 msgid "Account type tabs"
 msgstr ""
 
-#: src\templates\sub\profiles.phtml:4 src\templates\sub\profiles.phtml:7
+#: src\templates\sub\profiles.phtml:4
+#: src\templates\sub\profiles.phtml:7
 msgid "Top %s pagination"
 msgstr ""
 
-#: src\templates\sub\profiles.phtml:13 src\templates\sub\profiles.phtml:16
+#: src\templates\sub\profiles.phtml:13
+#: src\templates\sub\profiles.phtml:16
 msgid "Bottom %s pagination"
 msgstr ""
 
-#: src\templates\statistics.phtml:64 src\templates\sub\server.phtml:15
+#: src\templates\statistics.phtml:66
+#: src\templates\sub\server.phtml:15
 msgid "Stable Version"
 msgstr "稳定版"
 
-#: src\templates\statistics.phtml:66 src\templates\sub\server.phtml:17
+#: src\templates\statistics.phtml:68
+#: src\templates\sub\server.phtml:17
 msgid "Develop Version"
 msgstr "开发版"
 
@@ -188,7 +198,8 @@ msgstr "热门语言"
 msgid "Popular Tags"
 msgstr "热门标签"
 
-#: src\templates\sub\server.phtml:44 src\templates\sub\server.phtml:45
+#: src\templates\sub\server.phtml:44
+#: src\templates\sub\server.phtml:45
 msgid "Default Language"
 msgstr "默认语言"
 
@@ -226,71 +237,51 @@ msgid "Profiles"
 msgstr ""
 
 #: src\templates\statistics.phtml:6
-msgid ""
-"This directory knows about <strong>%s distinct potential profile "
-"URLs</strong>."
+msgid "This directory knows about <strong>%s distinct potential profile URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:15 src\templates\statistics.phtml:44
+#: src\templates\statistics.phtml:16
+#: src\templates\statistics.phtml:46
 msgid "Languages"
 msgstr "语言"
 
-#: src\templates\statistics.phtml:16
-msgid ""
-"Out of <strong>%s</strong> profiles reporting their language there are:"
+#: src\templates\statistics.phtml:17
+msgid "Out of <strong>%s</strong> profiles reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:26
+#: src\templates\statistics.phtml:27
 msgid "Servers"
 msgstr "服务器"
 
-#: src\templates\statistics.phtml:27
-msgid ""
-"This directory knows about <strong>%s distinct potential server "
-"URLs</strong>."
-msgstr ""
-
 #: src\templates\statistics.phtml:28
-msgid ""
-"Out of those, there are <strong>%s domains (%s)</strong> that have been a "
-"Friendica server at least once."
+msgid "This directory knows about <strong>%s distinct potential server URLs</strong>."
 msgstr ""
 
-#: src\templates\statistics.phtml:32
+#: src\templates\statistics.phtml:29
+msgid "Out of those, there are <strong>%s domains (%s)</strong> that have been a Friendica server at least once."
+msgstr ""
+
+#: src\templates\statistics.phtml:33
 msgid "Out of those, there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:38
-msgid ""
-"<strong>%s public servers (%s)</strong> currently open for registration. <a "
-"href=\"/servers\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:45
+#: src\templates\statistics.phtml:47
 msgid "Out of <strong>%s</strong> servers reporting their language there are:"
 msgstr ""
 
-#: src\templates\statistics.phtml:55
+#: src\templates\statistics.phtml:57
 msgid "Versions"
 msgstr "版本"
 
-#: src\templates\statistics.phtml:56
+#: src\templates\statistics.phtml:58
 msgid "Out of <strong>%s</strong> servers reporting their version there are:"
 msgstr ""
 
 #: src\templates\statistics.phtml:7
-msgid ""
-"Out of those, there are <strong>%s profiles (%s)</strong> that opted in the "
-"public directory at least once."
+msgid "Out of those, there are <strong>%s profiles (%s)</strong> that opted in the public directory at least once."
 msgstr ""
 
-#: src\templates\statistics.phtml:11
-msgid ""
-"Out of those, there currently are <strong>%s available profiles "
-"(%s)</strong>. <a href=\"/\">Check them out!</a>"
-msgstr ""
-
-#: src\templates\statistics.phtml:34
+#: src\templates\statistics.phtml:35
 msgid "<strong>%s available servers (%s)</strong>"
 msgstr ""
 
@@ -301,3 +292,11 @@ msgstr "Friendica 目录版本 %s"
 #: src\templates\layout.phtml:94
 msgid "Source Code on GitHub"
 msgstr "源码托管于 GitHub"
+
+#: src\templates\statistics.phtml:11
+msgid "Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href=\"%s\">Check them out!</a>"
+msgstr ""
+
+#: src\templates\statistics.phtml:39
+msgid "<strong>%s public servers (%s)</strong> currently open for registration. <a href=\"%s\">Check them out!</a>"
+msgstr ""

--- a/src/middleware.php
+++ b/src/middleware.php
@@ -52,3 +52,5 @@ $middleware->setLocaleCallback(function (string $locale) use ($container) {
 $middleware->setUriParamName('lang');
 
 $app->add($middleware);
+
+$app->add(new \Friendica\Directory\Middleware\ZrlMiddleware($container->get('renderer')));

--- a/src/routes.php
+++ b/src/routes.php
@@ -10,7 +10,7 @@ use Slim\Http\Response;
  */
 
 $app->get('/servers/surprise', \Friendica\Directory\Routes\Http\Surprise::class);
-$app->get('/servers', \Friendica\Directory\Routes\Web\Servers::class);
+$app->get('/servers', \Friendica\Directory\Routes\Web\Servers::class)->setName('servers');
 
 $app->get('/search[/{account_type}]', function (Request $request, Response $response, $args) {
 	if ($request->getAttribute('negotiation')->getMediaType() == 'application/json') {
@@ -24,7 +24,7 @@ $app->get('/search[/{account_type}]', function (Request $request, Response $resp
 
 $app->post('/msearch', \Friendica\Directory\Routes\Http\MatchSearch::class);
 
-$app->get('/stats', \Friendica\Directory\Routes\Web\Statistics::class);
+$app->get('/stats', \Friendica\Directory\Routes\Web\Statistics::class)->setName('stats');
 
 $app->get('/submit', \Friendica\Directory\Routes\Http\Submit::class);
 

--- a/src/templates/layout.phtml
+++ b/src/templates/layout.phtml
@@ -13,12 +13,12 @@
 <!-- Navigation -->
 <nav class="navbar navbar-expand-lg navbar-light bg-light static-top">
     <div class="container">
-        <a class="navbar-brand" href="">
+        <a class="navbar-brand" href="<?php echo $this->escapeHtmlAttr($this->u(''))?>">
             <img src="assets/images/friendica-32.png" width="32" height="32" class="d-inline-block align-top" alt="">
 	        <?php echo $this->__('Friendica Directory')?>
         </a>
 		<?php if (empty($noNavSearch)): ?>
-            <form class="form-inline my-2 my-lg-0 d-none d-md-flex" action="search">
+            <form class="form-inline my-2 my-lg-0 d-none d-md-flex" action="<?php echo $this->escapeHtmlAttr($this->r('search'))?>">
                 <div class="input-group">
                     <label class="sr-only" for="header_search"><?php echo $this->__('Search terms')?></label>
                     <input name="q" class="form-control" type="search" id="header_search" placeholder="<?php echo $this->p__('noun', 'Search')?>..."
@@ -38,7 +38,7 @@
             <ul class="navbar-nav ml-auto">
 				<?php if (empty($noNavSearch)): ?>
                     <li class="nav-item d-md-none">
-                        <form action="search">
+                        <form action="<?php echo $this->escapeHtmlAttr($this->r('search'))?>">
                             <div class="input-group">
                                 <label class="sr-only" for="nav_search"><?php echo $this->__('Search terms')?></label>
                                 <input name="q" class="form-control form-control-sm" type="search" id="nav_search"
@@ -52,12 +52,12 @@
 				<?php endif; ?>
 
                 <li class="nav-item">
-                    <a class="nav-link" href=""><i class="fa fa-address-card"></i> <?php echo $this->__('Directory')?>
+                    <a class="nav-link" href="<?php echo $this->escapeHtmlAttr($this->u(''))?>"><i class="fa fa-address-card"></i> <?php echo $this->__('Directory')?>
                         <!--<span class="sr-only">(current)</span>-->
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="servers"><i class="fa fa-hotel"></i> <?php echo $this->__('Public servers')?></a>
+                    <a class="nav-link" href="<?php echo $this->escapeHtmlAttr($this->r('servers'))?>"><i class="fa fa-hotel"></i> <?php echo $this->__('Public servers')?></a>
                 </li>
                 <li class="nav-item">
                     <div class="dropdown">
@@ -66,7 +66,7 @@
                         </button>
                         <div class="dropdown-menu" aria-labelledby="languageDropdown">
                     <?php foreach($languages as $lang):?>
-                            <a class="dropdown-item" href="?lang=<?php echo $this->escapeUrl($lang)?>">
+                            <a class="dropdown-item" href="<?php echo $this->escapeHtmlAttr($this->u('?lang=' . $lang))?>">
 	                            <?php echo $this->e(Friendica\Directory\Utils\L10n::localeToLanguageString($lang)) ?>
                             </a>
                     <?php endforeach;?>
@@ -94,11 +94,11 @@
                 <a class="nav-link" href="https://github.com/friendica/friendica-directory"><?php echo $this->__('Source Code on GitHub')?> <i class="fa fa-external-link-alt"></i></a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="stats"><i class="fa fa-clipboard-list"></i> <?php echo $this->__('Stats')?></a>
+                <a class="nav-link" href="<?php echo $this->escapeHtmlAttr($this->r('stats'))?>"><i class="fa fa-clipboard-list"></i> <?php echo $this->__('Stats')?></a>
             </li>
             <?php foreach ($pages as $page):?>
             <li class="nav-item">
-                <a class="nav-link" href="<?php echo strtolower(basename($page, '.html'))?>"><?php echo str_replace('_', ' ', basename($page, '.html'))?></a>
+                <a class="nav-link" href="<?php echo $this->u(strtolower(basename($page, '.html')))?>"><?php echo str_replace('_', ' ', basename($page, '.html'))?></a>
             </li>
             <?php endforeach;?>
         </ul>

--- a/src/templates/search.phtml
+++ b/src/templates/search.phtml
@@ -1,5 +1,5 @@
 <!--<h1>Search</h1>-->
-<form action="search">
+<form action="<?php echo $this->escapeHtmlAttr($this->r('search'))?>">
     <div class="input-group">
         <label class="sr-only" for="search_search"><?php echo $this->__('Search terms')?></label>
     <?php if ($field):?>

--- a/src/templates/statistics.phtml
+++ b/src/templates/statistics.phtml
@@ -8,9 +8,10 @@ use \Friendica\Directory\Utils\L10n;
         L10n::formatNumber($stats['profile']['total']),
         L10n::formatNumber($stats['profile']['ratio'], L10n::PERCENT)
     )?></p>
-<p><?php echo $this->__('Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href="/">Check them out!</a>',
+<p><?php echo $this->__('Out of those, there currently are <strong>%s available profiles (%s)</strong>. <a href="%s">Check them out!</a>',
 		L10n::formatNumber($stats['profile']['available']['total']),
-        L10n::formatNumber($stats['profile']['available']['ratio'], L10n::PERCENT)
+        L10n::formatNumber($stats['profile']['available']['ratio'], L10n::PERCENT),
+		$this->escapeHtmlAttr($this->u(''))
     )?></p>
 <h3><?php echo $this->__('Languages') ?></h3>
 <p><?php echo $this->__('Out of <strong>%s</strong> profiles reporting their language there are:', L10n::formatNumber($stats['profile']['language']['total']))?></p>
@@ -35,9 +36,10 @@ use \Friendica\Directory\Utils\L10n;
         L10n::formatNumber($stats['server']['available']['total']),
         L10n::formatNumber($stats['server']['available']['ratio'], L10n::PERCENT)
     )?></li>
-    <li><?php echo $this->__('<strong>%s public servers (%s)</strong> currently open for registration. <a href="/servers">Check them out!</a>',
+    <li><?php echo $this->__('<strong>%s public servers (%s)</strong> currently open for registration. <a href="%s">Check them out!</a>',
         L10n::formatNumber($stats['server']['open']['total']),
-        L10n::formatNumber($stats['server']['open']['ratio'], L10n::PERCENT)
+        L10n::formatNumber($stats['server']['open']['ratio'], L10n::PERCENT),
+		$this->escapeHtmlAttr($this->r('servers'))
     )?></li>
 </ul>
 

--- a/src/templates/sub/profile.phtml
+++ b/src/templates/sub/profile.phtml
@@ -1,19 +1,19 @@
 <?php
 $parts = [];
 if (!empty($profile['locality'])) {
-	$parts[] = $this->escapeHtml($profile['locality']) . ' <a href="search?field=locality&q=' . $this->escapeUrl($profile['locality']) . '">
+	$parts[] = $this->escapeHtml($profile['locality']) . ' <a href="' . $this->escapeHtmlAttr($this->r('search', [], ['field' => 'locality', 'q' => $profile['locality']])) . '">
         <span class="fa fa-filter" title="' . $this->__('Filter by locality') . '" aria-hidden="true"></span>
     </a>';
 }
 if (!empty($profile['region'])
 	&& strtolower($profile['locality']) != strtolower($profile['region'])) {
-	$parts[] = $this->escapeHtml($profile['region']) . ' <a href="search?field=region&q=' . $this->escapeUrl($profile['region']) . '">
+	$parts[] = $this->escapeHtml($profile['region']) . ' <a href="' . $this->escapeHtmlAttr($this->r('search', [], ['field' => 'region', 'q' => $profile['region']])) . '">
         <span class="fa fa-filter" title="' . $this->__('Filter by region') . '" aria-hidden="true"></span>
     </a>';
 }
 
 if (!empty($profile['country'])) {
-	$parts[] = $this->escapeHtml($profile['country']) . ' <a href="search?field=country&q=' . $this->escapeUrl($profile['country']) . '">
+	$parts[] = $this->escapeHtml($profile['country']) . ' <a href="' . $this->escapeHtmlAttr($this->r('search', [], ['field' => 'country', 'q' => $profile['country']])) . '">
         <span class="fa fa-filter" title="' . $this->__('Filter by country') . '" aria-hidden="true"></span>
     </a>';
 }
@@ -21,20 +21,20 @@ if (!empty($profile['country'])) {
 
 <figure id="profile-<?php echo $this->escapeHtmlAttr($profile['id']) ?>" class="bg-light p-3 rounded">
     <div class="media">
-        <a href="<?php echo $this->escapeHtmlAttr($profile['profile_url']) ?>">
+        <a href="<?php echo $this->escapeHtmlAttr($this->u($profile['profile_url'])) ?>">
             <img class="mr-3 rounded" src="photo/<?php echo $profile['id'] ?>.jpg">
         </a>
         <div class="media-body">
             <h5 class="name">
 				<?php if ($profile['dfrn_request']): ?>
-                    <a href="<?php echo $profile['dfrn_request']; ?>" class="card-link btn btn-primary float-right">
+                    <a href="<?php echo $this->escapeHtmlAttr($this->u($profile['dfrn_request'])); ?>" class="card-link btn btn-primary float-right">
                         <i class="fa fa-external-link-alt"></i> <?php echo $this->p__('verb', 'Follow')?>
                     </a>
 				<?php endif; ?>
 				<?php echo $this->escapeHtml($profile['name']) ?>
             </h5>
             <p class="url">
-                <a href="<?php echo $this->escapeHtmlAttr($profile['profile_url']) ?>">
+                <a href="<?php echo $this->escapeHtmlAttr($this->u($profile['profile_url'])) ?>">
                     <?php echo $this->escapeHtml($profile['addr']) ?>
                 </a>
             </p>
@@ -46,7 +46,7 @@ if (!empty($profile['country'])) {
     <div class="language">
         <i class="fa fa-language" alt="<?php echo $this->__('Language')?>" title="<?php echo $this->__('Language')?>"></i>
         <?php echo $this->e(Friendica\Directory\Utils\L10n::localeToLanguageString($profile['language'])) ?>
-        <a href="/search?field=language&amp;q=<?php echo $this->escapeUrl($profile['language']) ?>">
+        <a href="<?php echo $this->escapeHtmlAttr($this->r('search', [], ['field' => 'language', 'q' => $profile['language']])) ?>">
             <i class="fa fa-filter" title="<?php echo $this->__('Filter by language')?>"></i>
         </a>
     </div>
@@ -65,7 +65,7 @@ if (!empty($profile['country'])) {
 			foreach ($tags as $tag):?>
                 <span class="badge">
                     <?php echo $this->escapeHtml($tag) ?>
-                    <a href="/search?q=<?php echo $this->escapeUrl($tag) ?>">
+                    <a href="<?php echo $this->escapeHtmlAttr($this->r('search', [], ['q' => $tag])) ?>">
                         <i class="fa fa-tag" title="<?php echo $this->__('Search Tag')?>"></i>
                     </a>
                 </span>

--- a/src/templates/sub/server.phtml
+++ b/src/templates/sub/server.phtml
@@ -34,7 +34,7 @@ $base_url_display = substr($base_url, strpos($base_url, '/') + 2);
 				<?php else: ?>
                     <span class="badge badge-secondary"><i class="fa fa-lock-open"></i> HTTP</span>
 				<?php endif; ?>
-                <a href="<?php echo $base_url; ?>"><?php echo $this->e($base_url_display); ?></a>
+                <a href="<?php echo $this->escapeHtmlAttr($this->u($base_url)); ?>"><?php echo $this->e($base_url_display); ?></a>
             </h6>
             <p class="card-text">
                 <span class="badge <?php echo $badge_class ?>">
@@ -51,7 +51,7 @@ $base_url_display = substr($base_url, strpos($base_url, '/') + 2);
                 </span>
 				<?php echo $version_badge; ?>
             <?php if ($server['admin_profile'] && $server['admin_name']): ?>
-                <a href="<?php echo $server['admin_profile']; ?>" class="badge badge-primary">
+                <a href="<?php echo $this->escapeHtmlAttr($this->u($server['admin_profile'])); ?>" class="badge badge-primary">
                     <i class="fa fa-star"></i> <?php echo $this->__('Admin')?>: <?php echo $this->e($server['admin_name']); ?>
                 </a>
             <?php endif; ?>
@@ -61,7 +61,7 @@ $base_url_display = substr($base_url, strpos($base_url, '/') + 2);
 			<?php else: ?>
                 <p class="card-text text-muted">&lt;<?php echo $this->__('No description provided')?>&gt;</p>
 			<?php endif; ?>
-            <a href="<?php echo $base_url; ?>" class="card-link btn btn-primary"><i class="fa fa-external-link-alt"></i>
+            <a href="<?php echo $this->escapeHtmlAttr($this->u($base_url)); ?>" class="card-link btn btn-primary"><i class="fa fa-external-link-alt"></i>
 	            <?php echo $this->__('Visit Server')?></a>
         </div>
     </div>

--- a/src/templates/widget/accounttypetabs.phtml
+++ b/src/templates/widget/accounttypetabs.phtml
@@ -2,7 +2,7 @@
 	<?php foreach ($tabs as $tab): ?>
         <li class="nav-item">
             <a class="nav-link<?php echo $tab['active'] ? ' active' : '' ?>"
-               href="<?php echo $this->escapeHtmlAttr($tab['link']) ?>"><?php echo $this->e($tab['title']) ?></a>
+               href="<?php echo $this->escapeHtmlAttr($this->u($tab['link'])) ?>"><?php echo $this->e($tab['title']) ?></a>
         </li>
 	<?php endforeach; ?>
 </ul>

--- a/src/templates/widget/popularcountries.phtml
+++ b/src/templates/widget/popularcountries.phtml
@@ -3,7 +3,7 @@
     <ul>
 		<?php foreach ($countries as $country): ?>
             <li>
-                <a href="search?field=country&q=<?php echo $this->escapeUrl($country['country']) ?>">
+                <a href="<?php echo $this->escapeHtmlAttr($this->r('search', [], ['field' => 'country', 'q' => $country['country']])) ?>">
 					<?php echo $this->e($country['country']) ?>
                 </a>
             </li>

--- a/src/templates/widget/popularlanguages.phtml
+++ b/src/templates/widget/popularlanguages.phtml
@@ -3,7 +3,7 @@
     <ul>
 		<?php foreach ($languages as $language): ?>
             <li>
-                <a href="search?field=language&q=<?php echo $this->escapeUrl($language['language']) ?>">
+                <a href="<?php echo $this->escapeHtmlAttr($this->r('search', [], ['field' => 'language', 'q' => $language['language']])) ?>">
 					<?php echo $this->e(Friendica\Directory\Utils\L10n::localeToLanguageString($language['language'])) ?>
                 </a>
             </li>

--- a/src/templates/widget/populartags.phtml
+++ b/src/templates/widget/populartags.phtml
@@ -3,7 +3,7 @@
     <ul>
 		<?php foreach ($tags as $tag): ?>
             <li>
-                <a href="search?q=<?php echo $this->escapeUrl($tag['term']) ?>">
+                <a href="<?php echo $this->escapeHtmlAttr($this->r('search', [], ['q' => $tag['term']])) ?>">
 					<?php echo $this->e($tag['term']) ?>
                 </a>
             </li>


### PR DESCRIPTION
Closes #24 

I've long wondered how to best support the `zrl` parameter within the Slim framework context. I was stuck for a while because I needed to find the intersection of the Request object that contains the query parameter, the Router to generate URLs for routes including the parameter, and the Renderer to append the parameter to external URLs (not handled by the internal router).

The solution was to use a midlleware class to extract the query string parameter from the request and store it as an attribute of the Renderer, then have the Router be a dependency of the Renderer, then write two Renderer helper methods to append automatically the zrl parameter to route URLs and external URLs repsectively.

Then I had to replace all the hard-coded URLs in the templates with either method calls.

In the end, it was easier than I initially expected, but it took me a while to wrap my head around the dependency injection philosophy I'm trying to use through Slim.