### PR TITLE
Remove validity check on profile key parameter

### DIFF
--- a/src/classes/Pollers/Profile.php
+++ b/src/classes/Pollers/Profile.php
@@ -333,9 +333,6 @@ class Profile
 	private static function validateParams(array $params): int
 	{
 		$errors = 0;
-		if (empty($params['key'])) {
-			$errors++;
-		}
 		if (empty($params['dfrn-request'])) {
 			$errors++;
 		}

--- a/src/classes/Utils/Scrape.php
+++ b/src/classes/Utils/Scrape.php
@@ -129,7 +129,7 @@ class Scrape
 
 		$nodes_left = max(intval($max_nodes), $minNodes);
 		$items = $dom->getElementsByTagName('*');
-		$targets = array('fn', 'pdesc', 'photo', 'key', 'locality', 'region', 'postal-code', 'country-name');
+		$targets = array('fn', 'pdesc', 'photo', 'locality', 'region', 'postal-code', 'country-name');
 		$targets_left = count($targets);
 		foreach ($items as $item) {
 			if (self::attributeContains($item->getAttribute('class'), 'vcard')) {
@@ -146,10 +146,6 @@ class Scrape
 					if (self::attributeContains($vcard_element->getAttribute('class'), 'photo')) {
 						$params['photo'] = $vcard_element->getAttribute('src');
 						$targets_left = self::popScrapeTarget($targets, 'photo');
-					}
-					if (self::attributeContains($vcard_element->getAttribute('class'), 'key')) {
-						$params['key'] = $vcard_element->textContent;
-						$targets_left = self::popScrapeTarget($targets, 'key');
 					}
 					if (self::attributeContains($vcard_element->getAttribute('class'), 'locality')) {
 						$params['locality'] = $vcard_element->textContent;


### PR DESCRIPTION
Fixes #45 

Many valid profiles scrapes were missing the `key` parameter, which made them considered invalid. The legacy check on the `key` parameter has now been removed as we don't use this particular piece of data in the directory and valid profiles can miss this data.