### PR TITLE
[Database v0006] Drop unused server.path field

### DIFF
--- a/src/sql/migrations/down/0005.sql
+++ b/src/sql/migrations/down/0005.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE `server` ADD `path` varchar(190) NOT NULL DEFAULT '' AFTER `base_url`;
+COMMIT;

--- a/src/sql/migrations/up/0006.sql
+++ b/src/sql/migrations/up/0006.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE `server` DROP COLUMN `path`;
+COMMIT;


### PR DESCRIPTION
Fixes #47 

- Fix "Field 'path' doesn't have a default value" errors

