### PR TITLE
Add missing column in profile fulltext index 

### DIFF
--- a/src/classes/Controllers/Api/Search.php
+++ b/src/classes/Controllers/Api/Search.php
@@ -47,7 +47,7 @@ class Search
 			$query .= '%';
 			$sql_where = '`' . $field . '` LIKE :query';
 		} else {
-			$sql_where = "MATCH (p.`name`, p.`pdesc`, p.`profile_url`, p.`locality`, p.`region`, p.`country`, p.`tags` )
+			$sql_where = "MATCH (p.`name`, p.`pdesc`, p.`username`, p.`locality`, p.`region`, p.`country`, p.`tags` )
 AGAINST (:query IN BOOLEAN MODE)";
 		}
 

--- a/src/sql/migrations/down/0001.sql
+++ b/src/sql/migrations/down/0001.sql
@@ -1,0 +1,2 @@
+BEGIN;
+COMMIT;

--- a/src/sql/migrations/down/0006.sql
+++ b/src/sql/migrations/down/0006.sql
@@ -1,0 +1,2 @@
+BEGIN;
+COMMIT;

--- a/src/sql/migrations/down/0007.sql
+++ b/src/sql/migrations/down/0007.sql
@@ -1,4 +1,4 @@
 BEGIN;
 ALTER TABLE `profile` DROP KEY `profile-ft`;
-ALTER TABLE `profile` ADD FULLTEXT KEY `profile-ft` (`name`, `pdesc`, `profile_url`, `locality`, `region`, `country`);
+ALTER TABLE `profile` ADD FULLTEXT KEY `profile-ft` (`name`, `pdesc`, `profile_url`, `locality`, `region`, `country`, `tags`);
 COMMIT;

--- a/src/sql/migrations/up/0008.sql
+++ b/src/sql/migrations/up/0008.sql
@@ -1,4 +1,4 @@
 BEGIN;
 ALTER TABLE `profile` DROP KEY `profile-ft`;
-ALTER TABLE `profile` ADD FULLTEXT KEY `profile-ft` (`name`, `pdesc`, `username`, `locality`, `region`, `country`);
+ALTER TABLE `profile` ADD FULLTEXT KEY `profile-ft` (`name`, `pdesc`, `username`, `locality`, `region`, `country`, `tags`);
 COMMIT;


### PR DESCRIPTION
Fix #61
Follow-up to #60

For people working on the `stable` branch, they will have to run the updated queries in `src/sql/migrations/up/0008.sql` manually as the `updatedb` console command doesn't re-run migration scripts.