### PR TITLE
Fixes:

### DIFF
--- a/bin/cron.php
+++ b/bin/cron.php
@@ -15,9 +15,9 @@ require __DIR__ . '/../src/dependencies.php';
 
 (new \Friendica\Directory\Controllers\Cron(
 	$container->get('atlas'),
-	$container->get('\Friendica\Directory\Pollers\Profile'),
-	$container->get('\Friendica\Directory\Pollers\Server'),
-	$container->get('\Friendica\Directory\Pollers\Directory'),
+	$container->get(\Friendica\Directory\Pollers\Profile::class),
+	$container->get(\Friendica\Directory\Pollers\Server::class),
+	$container->get(\Friendica\Directory\Pollers\Directory::class),
 	$container->get('logger')
 ))->execute();
 

--- a/src/classes/Routes/Console/DirectoryPoll.php
+++ b/src/classes/Routes/Console/DirectoryPoll.php
@@ -11,7 +11,7 @@ class DirectoryPoll extends BaseRoute
 	{
 		return (new \Friendica\Directory\Controllers\Console\DirectoryPoll(
 			$this->container->get('atlas'),
-			$this->container->get('\Friendica\Directory\Pollers\Directory'),
+			$this->container->get(\Friendica\Directory\Pollers\Directory::class),
 			$args
 		));
 	}

--- a/src/classes/Routes/Console/ProfileAdd.php
+++ b/src/classes/Routes/Console/ProfileAdd.php
@@ -10,7 +10,7 @@ class ProfileAdd extends BaseRoute
 	public function __invoke(array $args)
 	{
 		return (new \Friendica\Directory\Controllers\Console\ProfileAdd(
-			$this->container->get('\Friendica\Directory\Models\ProfilePollQueue'),
+			$this->container->get(\Friendica\Directory\Models\ProfilePollQueue::class),
 			$args
 		));
 	}

--- a/src/classes/Routes/Console/ProfilePoll.php
+++ b/src/classes/Routes/Console/ProfilePoll.php
@@ -10,7 +10,7 @@ class ProfilePoll extends BaseRoute
 	public function __invoke(array $args)
 	{
 		return (new \Friendica\Directory\Controllers\Console\ProfilePoll(
-			$this->container->get('\Friendica\Directory\Pollers\Profile'),
+			$this->container->get(\Friendica\Directory\Pollers\Profile::class),
 			$args
 		));
 	}

--- a/src/classes/Routes/Console/ServerHide.php
+++ b/src/classes/Routes/Console/ServerHide.php
@@ -11,7 +11,7 @@ class ServerHide extends BaseRoute
 	{
 		return (new \Friendica\Directory\Controllers\Console\ServerHide(
 			$this->container->get('atlas'),
-			$this->container->get('\Friendica\Directory\Models\Server'),
+			$this->container->get(\Friendica\Directory\Models\Server::class),
 			$args
 		));
 	}

--- a/src/classes/Routes/Console/ServerPoll.php
+++ b/src/classes/Routes/Console/ServerPoll.php
@@ -11,7 +11,7 @@ class ServerPoll extends BaseRoute
 	{
 		return (new \Friendica\Directory\Controllers\Console\ServerPoll(
 			$this->container->get('atlas'),
-			$this->container->get('\Friendica\Directory\Pollers\Server'),
+			$this->container->get(\Friendica\Directory\Pollers\Server::class),
 			$args
 		));
 	}

--- a/src/classes/Routes/Http/MatchSearch.php
+++ b/src/classes/Routes/Http/MatchSearch.php
@@ -11,7 +11,7 @@ class MatchSearch extends BaseRoute
 	{
 		return (new \Friendica\Directory\Controllers\Api\MatchSearch(
 			$this->container->atlas,
-			$this->container->get('\Friendica\Directory\Models\Profile'),
+			$this->container->get(\Friendica\Directory\Models\Profile::class),
 			$this->container->l10n
 		))->render($request, $response, $args);
 	}

--- a/src/classes/Routes/Http/Search.php
+++ b/src/classes/Routes/Http/Search.php
@@ -11,7 +11,7 @@ class Search extends BaseRoute
 	{
 		return (new \Friendica\Directory\Controllers\Api\Search(
 			$this->container->atlas,
-			$this->container->get('\Friendica\Directory\Models\Profile'),
+			$this->container->get(\Friendica\Directory\Models\Profile::class),
 			$this->container->l10n
 		))->render($request, $response, $args);
 	}

--- a/src/classes/Routes/Http/Submit.php
+++ b/src/classes/Routes/Http/Submit.php
@@ -11,7 +11,7 @@ class Submit extends BaseRoute
 	{
 		return (new \Friendica\Directory\Controllers\Api\Submit(
 			$this->container->atlas,
-			$this->container->get('\Friendica\Directory\Models\ProfilePollQueue'),
+			$this->container->get(\Friendica\Directory\Models\ProfilePollQueue::class),
 			$this->container->logger
 		))->execute($request, $response);
 	}

--- a/src/classes/Routes/Web/Directory.php
+++ b/src/classes/Routes/Web/Directory.php
@@ -13,8 +13,8 @@ class Directory extends BaseRoute
 
 		$this->controller = new \Friendica\Directory\Controllers\Web\Directory(
 			$this->container->atlas,
-			$this->container->get('\Friendica\Directory\Models\Profile'),
-			$this->container->get('\Friendica\Directory\Views\Widget\AccountTypeTabs'),
+			$this->container->get(\Friendica\Directory\Models\Profile::class),
+			$this->container->get(\Friendica\Directory\Views\Widget\AccountTypeTabs::class),
 			$this->container->renderer,
 			$this->container->l10n
 		);

--- a/src/classes/Routes/Web/Search.php
+++ b/src/classes/Routes/Web/Search.php
@@ -13,8 +13,8 @@ class Search extends BaseRoute
 
 		$this->controller = new \Friendica\Directory\Controllers\Web\Search(
 			$this->container->atlas,
-			$this->container->get('\Friendica\Directory\Models\Profile'),
-			$this->container->get('\Friendica\Directory\Views\Widget\AccountTypeTabs'),
+			$this->container->get(\Friendica\Directory\Models\Profile::class),
+			$this->container->get(\Friendica\Directory\Views\Widget\AccountTypeTabs::class),
 			$this->container->renderer,
 			$this->container->l10n
 		);

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -91,52 +91,52 @@ $container['migration'] = function (ContainerInterface $c): ByJG\DbMigration\Mig
 
 // Internal Dependency Injection
 
-$container['\Friendica\Directory\Models\Profile'] = function (ContainerInterface $c): Friendica\Directory\Models\Profile {
+$container[\Friendica\Directory\Models\Profile::class] = function (ContainerInterface $c): Friendica\Directory\Models\Profile {
 	return new Friendica\Directory\Models\Profile($c->get('atlas'));
 };
 
-$container['\Friendica\Directory\Models\ProfilePollQueue'] = function (ContainerInterface $c): Friendica\Directory\Models\ProfilePollQueue {
+$container[\Friendica\Directory\Models\ProfilePollQueue::class] = function (ContainerInterface $c): Friendica\Directory\Models\ProfilePollQueue {
 	return new Friendica\Directory\Models\ProfilePollQueue($c->get('atlas'));
 };
 
-$container['\Friendica\Directory\Models\Server'] = function (ContainerInterface $c): Friendica\Directory\Models\Server {
+$container[\Friendica\Directory\Models\Server::class] = function (ContainerInterface $c): Friendica\Directory\Models\Server {
 	return new Friendica\Directory\Models\Server($c->get('atlas'));
 };
 
-$container['\Friendica\Directory\Pollers\Directory'] = function (ContainerInterface $c): Friendica\Directory\Pollers\Directory {
+$container[\Friendica\Directory\Pollers\Directory::class] = function (ContainerInterface $c): Friendica\Directory\Pollers\Directory {
 	$settings = $c->get('settings')['poller'];
 	return new Friendica\Directory\Pollers\Directory(
 		$c->get('atlas'),
-		$c->get('\Friendica\Directory\Models\ProfilePollQueue'),
+		$c->get(\Friendica\Directory\Models\ProfilePollQueue::class),
 		$c->get('logger'),
 		$settings ?: []
 	);
 };
 
-$container['\Friendica\Directory\Pollers\Profile'] = function (ContainerInterface $c): Friendica\Directory\Pollers\Profile {
+$container[\Friendica\Directory\Pollers\Profile::class] = function (ContainerInterface $c): Friendica\Directory\Pollers\Profile {
 	$settings = $c->get('settings')['poller'];
 	return new Friendica\Directory\Pollers\Profile(
 		$c->get('atlas'),
-		$c->get('\Friendica\Directory\Models\Server'),
-		$c->get('\Friendica\Directory\Models\Profile'),
+		$c->get(\Friendica\Directory\Models\Server::class),
+		$c->get(\Friendica\Directory\Models\Profile::class),
 		$c->get('logger'),
 		$settings ?: []
 	);
 };
 
-$container['\Friendica\Directory\Pollers\Server'] = function (ContainerInterface $c): Friendica\Directory\Pollers\Server {
+$container[\Friendica\Directory\Pollers\Server::class] = function (ContainerInterface $c): Friendica\Directory\Pollers\Server {
 	$settings = $c->get('settings')['poller'];
 	return new Friendica\Directory\Pollers\Server(
 		$c->get('atlas'),
-		$c->get('\Friendica\Directory\Models\ProfilePollQueue'),
-		$c->get('\Friendica\Directory\Models\Server'),
+		$c->get(\Friendica\Directory\Models\ProfilePollQueue::class),
+		$c->get(\Friendica\Directory\Models\Server::class),
 		$c->get('simplecache'),
 		$c->get('logger'),
 		$settings ?: []
 	);
 };
 
-$container['\Friendica\Directory\Views\Widget\AccountTypeTabs'] = function (ContainerInterface $c): Friendica\Directory\Views\Widget\AccountTypeTabs {
+$container[\Friendica\Directory\Views\Widget\AccountTypeTabs::class] = function (ContainerInterface $c): Friendica\Directory\Views\Widget\AccountTypeTabs {
 	return new Friendica\Directory\Views\Widget\AccountTypeTabs(
 		$c->get('atlas'),
 		$c->get('renderer'),


### PR DESCRIPTION
- timeout of 1 second was to short for the default directory at https://dir.friendica.social
- Used \Some\Foo::class instead of '\Some\Foo' which type-safe and easier to find by your editor/IDE

Signed-off-by: Roland Häder <roland@mxchange.org>