### PR TITLE
Remove at sign (@) from fulltext query string

### DIFF
--- a/src/classes/Controllers/Api/MatchSearch.php
+++ b/src/classes/Controllers/Api/MatchSearch.php
@@ -48,6 +48,8 @@ class MatchSearch
 		$pager->setPage(filter_input(INPUT_POST, 'p', FILTER_SANITIZE_NUMBER_INT));
 
 		$sql_where = "MATCH (p.`tags`) AGAINST (:query)";
+		// At sign (@) is a reserved symbol in InnoDB full-text search, it can't be escaped
+		$query = str_replace('@', ' ', $query);
 
 		$values = ['query' => $query];
 

--- a/src/classes/Controllers/Api/Search.php
+++ b/src/classes/Controllers/Api/Search.php
@@ -51,6 +51,8 @@ class Search
 		} else {
 			$sql_where = "MATCH (p.`name`, p.`pdesc`, p.`username`, p.`locality`, p.`region`, p.`country`, p.`tags` )
 AGAINST (:query IN BOOLEAN MODE)";
+			// At sign (@) is a reserved symbol in InnoDB full-text search, it can't be escaped
+			$query = str_replace('@', ' ', $query);
 		}
 
 		$values = ['query' => $query];

--- a/src/classes/Controllers/Web/Search.php
+++ b/src/classes/Controllers/Web/Search.php
@@ -73,6 +73,8 @@ class Search extends BaseController
 		} else {
 			$sql_where = "MATCH (p.`name`, p.`pdesc`, p.`username`, p.`locality`, p.`region`, p.`country`, p.`tags` )
 AGAINST (:query IN BOOLEAN MODE)";
+			// At sign (@) is a reserved symbol in InnoDB full-text search, it can't be escaped
+			$query = str_replace('@', ' ', $query);
 		}
 
 		$values = ['query' => $query];


### PR DESCRIPTION
- InnoDB uses it as a special character and it can't be escaped

Fixes #76